### PR TITLE
Bump to 0.0.7, update JSS dep to >=0.0.136

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servejss",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Static file server with REST write support - npx serve alternative",
   "keywords": [
     "serve",
@@ -27,7 +27,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "javascript-solid-server": ">=0.0.91"
+    "javascript-solid-server": ">=0.0.136"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Bump version to 0.0.7 for npm publish
- Update `javascript-solid-server` dependency from `>=0.0.91` to `>=0.0.136`

Ensures the git HTTP backend support required by #2 is available.